### PR TITLE
Better code reuse with _setupOAuth()

### DIFF
--- a/application_boilerplate/js/template.js
+++ b/application_boilerplate/js/template.js
@@ -76,11 +76,7 @@ function(
                     this._queryUrlParams();
                     //setup OAuth if oauth appid exists
                     if (this.config.oauthappid) {
-                        OAuthHelper.init({
-                            appId: this.config.oauthappid,
-                            portal: this.config.sharinghost,
-                            expiration: (14 * 24 * 60) //2 weeks (in minutes)
-                        });
+                        this._setupOAuth(this.config.oauthappid, this.config.sharinghost);
                     }
                     deferred.resolve();
                 }));


### PR DESCRIPTION
I'm sorry in advance if there is some reason _not_ to call `_setupOAuth()`!  

I think `lang.hitch()` makes calling `this. _setupOAuth()` possible without any surprise scoping issues.  If I'm right, this changeset improves code reuse without introducing any bug.
