### PR TITLE
Special handling of 'localhost' for the auth cookie.

### DIFF
--- a/application_boilerplate/js/OAuthHelper.js
+++ b/application_boilerplate/js/OAuthHelper.js
@@ -81,11 +81,21 @@ function(lang, dojoJson, Url, cookie, Deferred, ioquery, idManager) {
                     var credential = this.registerToken(oauthResponse);
                     // User checked "Keep me signed in" option
                     if (oauthResponse.persist) {
-                        cookie("arcgis_auth", dojoJson.toJson(oauthResponse), {
-                            expires: new Date(oauthResponse.expires_at),
-                            path: "/",
-                            domain: document.domain
-                        });
+                        if (document.domain === "localhost") {
+                            // Do not include the domain because "localhost" won't work. See http://stackoverflow.com/a/489465
+                            cookie("arcgis_auth", dojoJson.toJson(oauthResponse), {
+                                expires: new Date(oauthResponse.expires_at),
+                                path: "/"
+                            });
+                        }
+                        else {
+                            // Include the domain
+                            cookie("arcgis_auth", dojoJson.toJson(oauthResponse), {
+                                expires: new Date(oauthResponse.expires_at),
+                                path: "/",
+                                domain: document.domain
+                            });
+                        }
                         console.log("[Cookie] Write: ", cookie("arcgis_auth"));
                     }
                     if (this.deferred) {


### PR DESCRIPTION
This is my solution for running the app at `http://localhost`.  Without this change, the cookie is never created because "localhost" is apparently an invalid value for the cookie's domain (tested in Chrome latest and IE 10).  I can login to the app  without this change, but I'm forced to login again with every page refresh.
