### PR TITLE
App needs access to boilderplate settings

### DIFF
--- a/js/application/init.js
+++ b/js/application/init.js
@@ -198,6 +198,7 @@ define([
           // Launch the app specifics
           this.main.start({
             config: this.config,
+            settings: this.settings,
             view: view,
             webMap: webmap
           });
@@ -250,6 +251,7 @@ define([
           // Launch the app specifics
           this.main.start({
             config: this.config,
+            settings: this.settings,
             view: view,
             webScene: webscene
           });
@@ -275,6 +277,7 @@ define([
       // Launch the app specifics
       this.main.start({
         config: this.config,
+        settings: this.settings,
         groupInfo: info,
         groupItems: items
       });

--- a/js/application/main.js
+++ b/js/application/main.js
@@ -46,7 +46,7 @@ define([
      * Runs the custom part of an application following boilerplate completion.
      * @param {Object} options Structure containing 'config' (configuration assembled by boilerplate), and optional properties 'view' (resolved MapView or SceneView created in init),
      * 'webScene' (resolved WebScene created in init), 'webMap' (resolved WebMap created in init), 'groupInfo' (ArcGIS
-     * item groupInfo for group), 'groupItems' (list of groupItems in group)
+     * item groupInfo for group), 'groupItems' (list of groupItems in group), 'settings' (boilerplate underlying settings from settings.json)
      */
     start: function (options) {
 

--- a/js/boilerplate/settings.json
+++ b/js/boilerplate/settings.json
@@ -1,12 +1,12 @@
 {
   "webscene": {
-    "containerId": "viewDiv",
+    "containerId": "sceneViewDiv",
     "fetch": true,
     "useLocal": false,
     "localFile": "boilerplate/demoWebscene.json"
   },
   "webmap": {
-    "containerId": "viewDiv",
+    "containerId": "mapViewDiv",
     "fetch": true,
     "useLocal": false,
     "localFile": "boilerplate/demoWebmap.json"


### PR DESCRIPTION
An app might need to access the boilderplate settings. Let's pass this in as an optional parameter. I also uniquely named the div IDs for map and scene as some app templates might allow users to toggle between the two views and the divs need to be unique.