### PR TITLE
Allow to set default webmap or webscene

### DIFF
--- a/js/boilerplate/Boilerplate.js
+++ b/js/boilerplate/Boilerplate.js
@@ -535,11 +535,17 @@ define([
       if (geometryUrl) {
         // set the esri config to use the geometry service
         esriConfig.geometryServiceUrl = geometryUrl;
-      }
-      if (!this.config.webmap && this.settings.defaultWebmap) {
+      } 
+      // Default to webmap or webscene
+      if (!this.config.webmap && !this.config.webscene) {
+        if (this.settings.defaultWebmap) {
+          this.config.webmap = this.settings.defaultWebmap;
+        } else if (this.settings.defaultWebscene) {
+          this.config.webscene = this.settings.defaultWebscene;
+        }
+      } else if (this.config.webmap === "default" && this.settings.defaultWebmap) {
         this.config.webmap = this.settings.defaultWebmap;
-      }
-      if (!this.config.webscene && this.settings.defaultWebscene) {
+      } else if (this.config.webscene === "default"  && this.settings.defaultWebscene) {
         this.config.webscene = this.settings.defaultWebscene;
       }
       if (!this.config.group && this.settings.defaultGroup) {


### PR DESCRIPTION
How about this? Similar logic but also allows me to load the template with either the default webmap or webscene from the command line.

`http://localhost/GitHub/calcite-maps-styler-template/index.html?webmap=default`

`http://localhost/GitHub/calcite-maps-styler-template/index.html?webscene=default`