### PR TITLE
Expanded access check to check application item

### DIFF
--- a/application_boilerplate/js/template.js
+++ b/application_boilerplate/js/template.js
@@ -145,8 +145,8 @@ define([
             // mixin all new settings from item, group info and group items.
             this._mixinAll();
             // If app is private and logged in user doesn't have essential apps let them know.
-
-            if (this.config.itemInfo.item.access !== "public") {
+            if ((this.config.appResponse && this.config.appResponse.item.access !== "public") ||  // check app item
+              (this.config.itemInfo && this.config.itemInfo.item.access !== "public")) {          // check webmap if present
               if (response && response.code && response.code === "IdentityManagerBase.1") {
                 var licenseMessage = "<h1>" + this.i18nConfig.i18n.map.licenseError.title + "</h1><p>" + this.i18nConfig.i18n.map.licenseError.message + "</p>";
                 deferred.reject(new Error(licenseMessage));


### PR DESCRIPTION
Checking app item itself, which covers webmap-based and group-based apps, in addition to the webmap for webmap-based apps